### PR TITLE
Hyperlinks

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@ layout: default
 <div class="home">
 
 <form action="/search.html" method="get">
-    <label for="search_box">Search</label>
+    <label for="search_box"></label>
     <input type="text" id="search_box" name="query">
     <input type="submit" value="search">
 </form>
@@ -40,7 +40,7 @@ layout: default
   </button>
 
   <button type="button" class="btn btn-default">
-    <a href="/outdoors/">Outdoors</a>
+    <a href="/Outdoors/">Outdoors</a>
   </button>
 </div>
 

--- a/_posts/2018-01-02-guildhall_museum.markdown
+++ b/_posts/2018-01-02-guildhall_museum.markdown
@@ -4,7 +4,7 @@ title:  "The Guildhall Museum"
 date:   2018-01-02 12:48:04 +0000
 categories: [indoors, kent, museum]
 tags: Rochester
-permalink: guildhall-rochester
+permalink: 
 excerpt: A window into the key historical events in Rochester and the Medway River; from the siege of Rochester Castle to the Battle of the Medway. Step into the world of Dickensian Rochester and explore what it was like to live in the city at that time.  Discover the smelly, cramped Hulks that used to lie off the banks of the Medway in Rochester.
 ---
 

--- a/_posts/2018-01-02-maidstone-museum.markdown
+++ b/_posts/2018-01-02-maidstone-museum.markdown
@@ -4,7 +4,7 @@ title:  "Maidstone Museum"
 date:   2018-01-02 09:48:04 +0000
 categories: [indoors, kent, museum]
 tags: Maidstone
-permalink: maidstone-museum
+permalink: 
 excerpt: An eclectic mix of Maidstone based memorabilia from dinosaur fossils to World War 2 medals and uniforms.  Trails to follow, costumes to try on, ancient artifacts and tools and a dinosaur to hunt.
 ---
 

--- a/_posts/2018-01-03-cobtree-park.markdown
+++ b/_posts/2018-01-03-cobtree-park.markdown
@@ -4,7 +4,7 @@ title:  "Cobtree Manor Park"
 date:   2018-01-03 10:48:04 +0000
 categories: [outdoors, kent, park]
 tags: Maidstone
-permalink: cobtree-park
+permalink: 
 excerpt: A fantastic park on the site of the old Maidstone Zoo.  It has a great range of play equipment, a cafe with toilets and lovely walks through the gardens and woodland.
 ---
 

--- a/_posts/2018-01-03-whatman-park.markdown
+++ b/_posts/2018-01-03-whatman-park.markdown
@@ -4,7 +4,7 @@ title:  "Whatman Park"
 date:   2018-01-03 10:48:04 +0000
 categories: [outdoors, kent, park, sandpit]
 tags: Maidstone
-permalink: whatman-park
+permalink: 
 excerpt: A large park set on the banks of the River Medway, a short walk from Maidstone town centre.  It offers some lovely open spaces, several play areas and beautiful views of the river and its' wildlife.
 ---
 

--- a/_posts/2018-01-04-cliffe-park.markdown
+++ b/_posts/2018-01-04-cliffe-park.markdown
@@ -4,7 +4,7 @@ title:  "Cliffe Park"
 date:   2018-01-04 12:48:04 +0000
 categories: [outdoors, kent, park]
 tags: Cliffe
-permalink: cliffe-park
+permalink: 
 excerpt: A great little park in a country village located near some brilliant cycle routes and bird watching opportunities.
 ---
 

--- a/_posts/2018-01-10-riverside-gillingham.markdown
+++ b/_posts/2018-01-10-riverside-gillingham.markdown
@@ -22,7 +22,7 @@ There is plenty of free parking and the 131 and 190 buses stop near the country 
 
 Riverside Country Park is part of the [Saxon Shore Way](http://www.medway.gov.uk/pdf/walking_the_saxon_shore_way_through_medway.pdf) which offers extensive walks around the Kent coast line.  You could follow the paths and walk, run or cycle to The Strand Park.
 
-[The Strand Park](#) is a great play park a short drive (2 miles) from Riverside Country Park, or you could even cycle, run or walk there along the Saxon Shore Way. It offers several different play areas, cafe and toilets, a lido (charges apply) and splash pool (free) in the summer.
+[The Strand Park](/outdoors/kent/park/sandpit/2018/01/16/strand.html) is a great play park a short drive (2 miles) from Riverside Country Park, or you could even cycle, run or walk there along the Saxon Shore Way. It offers several different play areas, cafe and toilets, a lido (charges apply) and splash pool (free) in the summer.
 
 ## Gallery
 

--- a/_posts/2018-01-16-sheerness-sandpit.markdown
+++ b/_posts/2018-01-16-sheerness-sandpit.markdown
@@ -3,7 +3,7 @@ layout: post
 title:  "Sheerness Sandpit and splash pool"
 date:   2018-01-16 10:20:04 +0000
 categories: [outdoors, kent, sandpit, park]
-tag: Sheerness
+tags: Sheerness
 permalink: 
 excerpt: A fantastic sandpit park where you can spend several hours enjoying the lovely weather.  When you get bored of the sand there is a great splash pool and the beach is close by too.
 ---

--- a/_posts/2018-01-16-strand.markdown
+++ b/_posts/2018-01-16-strand.markdown
@@ -22,7 +22,7 @@ There is plenty of car parking which is pay and display.  Gillingham train stati
 
 Hilly Fields Community Park is only half a mile from The Strand.
 
-[Riverside Country Park](#) is 2 miles away and can be reach by car or by foot and cycle following the [Saxon Shore Way](http://www.medway.gov.uk/pdf/walking_the_saxon_shore_way_through_medway.pdf).  It offers more great play equipment and lovely walks around the River Wetlands where you can do some bird watching and nature spotting.
+[Riverside Country Park](/outdoors/kent/park/2018/01/10/riverside-gillingham.html) is 2 miles away and can be reach by car or by foot and cycle following the [Saxon Shore Way](http://www.medway.gov.uk/pdf/walking_the_saxon_shore_way_through_medway.pdf).  It offers more great play equipment and lovely walks around the River Wetlands where you can do some bird watching and nature spotting.
 
 Gillingham town centre is only 1 mile away and offers a variety of shops and food outlets.
 

--- a/about.md
+++ b/about.md
@@ -16,7 +16,7 @@ So pack up your picnic and find your next great day out.
   </button>
 
   <button type="button" class="btn btn-default">
-    <a href="/outdoors/">Outdoors</a>
+    <a href="/Outdoors/">Outdoors</a>
   </button>
 </div>
 
@@ -38,7 +38,7 @@ We need the help of everyone to build a website like this and really make it flo
 
 * e-mail us at [{{ site.email }}](mailto:{{ site.email }}") if you find something on our site that's not quite right, from spelling mistakes to out of date information, or even a better photograph you have taken and are willing to share.
 
-* Read the [New Locations](/new_locations/) page and e-mail us the information we need to share one of your favourite places to visit.  Remember it must be FREE to visit (we don't include parking charges in this).
+* Read the [Add Locations](/add_locations/) page and e-mail us the information we need to share one of your favourite places to visit.  Remember it must be FREE to visit (we don't include parking charges in this).
 
 * If you're a fellow coder check out our website from {% include icon-github.html %} [GitHub](https://github.com/Sam-Rowe/justaddapicnic.com) and build your own location page, we will then check and review it, and hopefully it will be included in the website.
 

--- a/category/indoors.md
+++ b/category/indoors.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Indoors
-permalink: indoors
+permalink: 
 ---
 
 

--- a/category/outdoors.md
+++ b/category/outdoors.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Outdoors
-permalink: outdoors
+permalink:
 ---
 
 


### PR DESCRIPTION
hyperlink issues hopefully resolved in the places mentioned in the issue log:

Many of the hyperlinks between the site pages are not working. This needs to be corrected.
Index page - Indoors and outdoors buttons not working
Header - indoors and outdoors buttons not working
About page - "New location" needs to be changed to "add locations" and then needs to take you to the right page. Indoors and Outdoors buttons are also not working.
From the search screen the following locations will not open - Maidstone museum, Cobtree, Whatman Park, Cliffe Park.
Hyperlinks between the strand and riverside pages need to be put in.